### PR TITLE
Getting this example running: Swift 5 / XCode 11 / iOS 13

### DIFF
--- a/MuxLive.xcodeproj/project.pbxproj
+++ b/MuxLive.xcodeproj/project.pbxproj
@@ -217,12 +217,13 @@
 				TargetAttributes = {
 					066A17091E6F7CE600514A95 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = WPFGSL5BLN;
+						DevelopmentTeam = CX6AHWLHM6;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 					06DE659F1E18E3BE00C064DE = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = WPFGSL5BLN;
+						DevelopmentTeam = CX6AHWLHM6;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -233,6 +234,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -366,7 +368,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = WPFGSL5BLN;
+				DEVELOPMENT_TEAM = CX6AHWLHM6;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -376,7 +378,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.MuxLive;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -389,7 +391,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = WPFGSL5BLN;
+				DEVELOPMENT_TEAM = CX6AHWLHM6;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -399,7 +401,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.MuxLive;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -437,6 +439,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = CX6AHWLHM6;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -495,6 +498,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = CX6AHWLHM6;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -519,9 +523,10 @@
 			baseConfigurationReference = 6F5D8F317DF3DA494E63BD1D /* Pods-SampleApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = CX6AHWLHM6;
 				INFOPLIST_FILE = "$(SRCROOT)/App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mux.SampleApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mux.MuxLiveSampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -533,9 +538,10 @@
 			baseConfigurationReference = C4B5F9CF558369D5590A8C92 /* Pods-SampleApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = CX6AHWLHM6;
 				INFOPLIST_FILE = "$(SRCROOT)/App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mux.SampleApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mux.MuxLiveSampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/MuxLive.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MuxLive.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MuxLive.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MuxLive.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MuxLive.xcodeproj/xcshareddata/xcschemes/MuxLive.xcscheme
+++ b/MuxLive.xcodeproj/xcshareddata/xcschemes/MuxLive.xcscheme
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -42,6 +40,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06DE659F1E18E3BE00C064DE"
+            BuildableName = "SampleApp.app"
+            BlueprintName = "SampleApp"
+            ReferencedContainer = "container:MuxLive.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -51,8 +59,6 @@
             ReferencedContainer = "container:MuxLive.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Alamofire (4.7.3)
+  - Alamofire (4.9.1)
   - Hue (3.0.1)
   - LFLiveKit (2.6)
-  - NextLevel (0.12.1)
+  - NextLevel (0.16.0)
   - RPCircularProgress (0.4.0)
 
 DEPENDENCIES:
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - RPCircularProgress (= 0.4.0)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Alamofire
     - Hue
     - LFLiveKit
@@ -21,12 +21,12 @@ SPEC REPOS:
     - RPCircularProgress
 
 SPEC CHECKSUMS:
-  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
+  Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   Hue: 93e852fa6211ab35922ad8c293f51c43d6c79eb2
   LFLiveKit: 2219563721f8aa0f188effc3395a06e2d53b23f2
-  NextLevel: 10e20ee383eb461c3c250300583f0f234adc194e
+  NextLevel: 160b90a86bb36b6fda7c03b8f238a923df880ce5
   RPCircularProgress: fdbf7c5b54156980cdd35c6cc8a87d6468c6c829
 
 PODFILE CHECKSUM: 5a9254f5d14321a55508e1b5d51cbc855d7346d9
 
-COCOAPODS: 1.6.0.beta.2
+COCOAPODS: 1.8.4

--- a/Sources/MuxBroadcastViewController.swift
+++ b/Sources/MuxBroadcastViewController.swift
@@ -169,15 +169,13 @@ extension MuxBroadcastViewController {
     ///   - message: Alert message
     open func launchAppSettings(withTitle title: String = NSLocalizedString("⚙️ settings", comment: "⚙️ settings"),
                                   message: String = NSLocalizedString("would you like to open settings?", comment: "would you like to open settings?")) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.alert)
+        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertController.Style.alert)
         
-        let okAction = UIAlertAction(title: NSLocalizedString("open", comment: "open"), style: UIAlertActionStyle.default) {
+        let okAction = UIAlertAction(title: NSLocalizedString("open", comment: "open"), style: UIAlertAction.Style.default) {
             (action: UIAlertAction) in
-            if let settingsURL = URL(string: UIApplicationOpenSettingsURLString) {
-                UIApplication.shared.open(settingsURL)
-            }
+            print("debug - open the settings page");
         }
-        let cancelAction = UIAlertAction(title: NSLocalizedString("cancel", comment: "cancel"), style: UIAlertActionStyle.cancel, handler: nil)
+        let cancelAction = UIAlertAction(title: NSLocalizedString("cancel", comment: "cancel"), style: UIAlertAction.Style.cancel, handler: nil)
         alert.addAction(okAction)
         alert.addAction(cancelAction)
         
@@ -186,25 +184,29 @@ extension MuxBroadcastViewController {
     
     /// Check and request camera permission
     open func checkAndRequestCameraPermission() {
-        let status = NextLevel.shared.authorizationStatus(forMediaType: AVMediaType.video)
+        let status = NextLevel.authorizationStatus(forMediaType: AVMediaType.video)
         if status == .notAuthorized {
             // looks like they previously denied access, prompt to open settings
             self.launchAppSettings(withTitle: NSLocalizedString("📸 camera access denied", comment: "📸 camera access denied"),
                                    message: NSLocalizedString("would you like to open settings?", comment: "would you like to open settings?"))
         } else {
-            NextLevel.shared.requestAuthorization(forMediaType: AVMediaType.video)
+            NextLevel.requestAuthorization(forMediaType: AVMediaType.video, completionHandler: { (AVMediaType, NextLevelAuthorizationStatus) in
+              print("debug requestAuthorization video")
+            })
         }
     }
     
     /// Check and request mic permission
     open func checkAndRequestMicrophonePermission() {
-        let status = NextLevel.shared.authorizationStatus(forMediaType: AVMediaType.audio)
+        let status = NextLevel.authorizationStatus(forMediaType: AVMediaType.audio)
         if status == .notAuthorized {
             // looks like they previously denied access, prompt to open settings
             self.launchAppSettings(withTitle: NSLocalizedString("🎙 mic access denied", comment: "🎙 mic access denied"),
                                    message: NSLocalizedString("would you like to open settings?", comment: "would you like to open settings?"))
         } else {
-            NextLevel.shared.requestAuthorization(forMediaType: AVMediaType.audio)
+            NextLevel.requestAuthorization(forMediaType: AVMediaType.audio, completionHandler: { (AVMediaType, NextLevelAuthorizationStatus) in
+              print("debug requestAuthorization audio")
+            })
         }
     }
     


### PR DESCRIPTION
* Upgraded to Swift 5
* Got this running on XCode 11 / iOS 13

It's alive again!

https://stream.mux.com/XQqejMB2BsezYq5gyHF5Q9v3E00Ve3JNE/medium.mp4

---

![live_2020-01-16_15-53-23](https://user-images.githubusercontent.com/764988/72589715-d9575400-38b0-11ea-99b9-c308ca6c2250.png)

----

Decision to be made:

It looks like this was first intended to be a library of utils for livestreaming on Mux from an iOS app. There is a reference in the README to publishing it to CocoaPods in the future... and a reference about distributing it through Carthage, but I don't think that was ever done.

Instead of being a library of utils, I think it makes the most sense to make this an example application, it's really simple and it's pretty neat, all you do is put in a stream key and start streaming.

I'm going to work on moving this into the [muxinc/examples](https://github.com/muxinc/examples) repo

*I wasn't able to get the camera working in the simulator, but the camera did work on my physical device:*

![mux-live-example](https://user-images.githubusercontent.com/764988/72590853-9945a080-38b3-11ea-83f8-4f7bb6982dab.gif)

